### PR TITLE
Fix typo for "tamper" switch

### DIFF
--- a/source/_components/binary_sensor.rfxtrx.markdown
+++ b/source/_components/binary_sensor.rfxtrx.markdown
@@ -132,5 +132,5 @@ The following devices are known to work with the rfxtrx binary sensor component.
   - Chuango PIR-700.
 
 - Door / window sensors:
-  - Kerui D026 door / window sensor: can trigger on "open" and "close". Has a temper switch.
+  - Kerui D026 door / window sensor: can trigger on "open" and "close". Has a tamper switch.
   - Nexa LMST-606 Magnetic contact switch.


### PR DESCRIPTION
**Description:**
Just a typo in the known working devices:
"temper switch" becomes "tamper switch" 😄 

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

